### PR TITLE
修复晶振计算错误、串口关闭错误等

### DIFF
--- a/wk2124s.c
+++ b/wk2124s.c
@@ -9,153 +9,153 @@
 
 void EXHW_WK2124_Write_Reg(struct rt_spi_device *device, uint8_t reg, uint8_t dat)
 {
-	static uint8_t sendbuf[10];
+    static uint8_t sendbuf[2];
 
-	sendbuf[0] = reg;
-	sendbuf[1] = dat;
+    sendbuf[0] = reg;
+    sendbuf[1] = dat;
 
-	rt_spi_send(device, sendbuf, 2);
+    rt_spi_send(device, sendbuf, 2);
 }
 
 uint8_t EXHW_WK2124_Read_Reg(struct rt_spi_device *device, uint8_t reg)
 {
-	static uint8_t sendbuf[10];
-	static uint8_t recbuf[10];
-	
-	sendbuf[0] = 0x40 + reg;
-	sendbuf[1] = 0x00;
-	rt_spi_transfer(device, sendbuf, recbuf, 2);
-	return recbuf[1];
+    static uint8_t sendbuf[2];
+    static uint8_t recbuf[2];
+    
+    sendbuf[0] = 0x40 | reg;
+    sendbuf[1] = 0x00;
+    rt_spi_transfer(device, sendbuf, recbuf, 2);
+    return recbuf[1];
 }
 
 void EXHW_WK2124_Write_FIFO(struct rt_spi_device *device, uint8_t reg, uint8_t *buf, uint16_t len)
 {
-	uint16_t cnt = 0;
-	uint8_t sendbuf[257];
+    uint16_t cnt = 0;
+    uint8_t sendbuf[257];
 
-	sendbuf[0] = 0x80 + reg;
-	for(cnt = 0; (cnt < len)&&(cnt < 256); cnt++) {
-		sendbuf[1+cnt] = buf[cnt];
-	} 
-	rt_spi_send(device, sendbuf, cnt+1);
+    sendbuf[0] = 0x80 | reg;
+    for(cnt = 0; (cnt < len)&&(cnt < 256); cnt++) {
+        sendbuf[1+cnt] = buf[cnt];
+    } 
+    rt_spi_send(device, sendbuf, cnt+1);
 }
 
 void EXHW_WK2124_Read_FIFO(struct rt_spi_device *device, uint8_t reg, uint8_t *buf, uint16_t len)
 {
-	uint16_t cnt = 0;
-	uint8_t sendbuf[257];
-	uint8_t recbuf[257];
-	uint16_t i = 0;
+    uint16_t cnt = 0;
+    uint8_t sendbuf[257];
+    uint8_t recbuf[257];
+    uint16_t i = 0;
 
-	sendbuf[0] = 0xC0 + reg;
-	for(cnt = 0; (cnt < len)&&(cnt < 256); cnt++) {
-		sendbuf[1+cnt] = 0x00;
-	} 
-	rt_spi_transfer(device, sendbuf, recbuf, cnt+1);
-	for ( i = 0; i < cnt; i++) {
-		buf[i] = recbuf[1+i];
-	}
+    sendbuf[0] = 0xC0 | reg;
+    for(cnt = 0; (cnt < len)&&(cnt < 256); cnt++) {
+        sendbuf[1+cnt] = 0x00;
+    } 
+    rt_spi_transfer(device, sendbuf, recbuf, cnt+1);
+    for ( i = 0; i < cnt; i++) {
+        buf[i] = recbuf[1+i];
+    }
 }
 
 uint16_t Wk2124_SendBuf(struct rt_spi_device *device, uint8_t index, uint8_t *sendbuf,uint16_t len)
 {
-	uint16_t ret = 0,tfcnt = 0,sendlen = 0;
-	uint8_t  fsr = 0;
-	
-	fsr = EXHW_WK2124_Read_Reg(device, SPAGE0_FSR(index));
-	if(~fsr & 0x02 )//子串口发送FIFO未满
-	{
-		tfcnt = EXHW_WK2124_Read_Reg(device, SPAGE0_TFCNT(index));//读子串口发送fifo中数据个数
-		sendlen = 256 - tfcnt;//FIFO能写入的最多字节数
+    uint16_t ret = 0,tfcnt = 0,sendlen = 0;
+    uint8_t  fsr = 0;
+    
+    fsr = EXHW_WK2124_Read_Reg(device, SPAGE0_FSR(index));
+    if(~fsr & 0x02 )//子串口发送FIFO未满
+    {
+        tfcnt = EXHW_WK2124_Read_Reg(device, SPAGE0_TFCNT(index));//读子串口发送fifo中数据个数
+        sendlen = 256 - tfcnt;//FIFO能写入的最多字节数
 
-		if(sendlen < len){
-			ret = sendlen; 
-			EXHW_WK2124_Write_FIFO(device, SPAGE0_FDAT(index),sendbuf,sendlen);
-		}else{
-			EXHW_WK2124_Write_FIFO(device, SPAGE0_FDAT(index),sendbuf,len);
-			ret = len;
-		}
-	}
-	return ret;
+        if(sendlen < len){
+            ret = sendlen; 
+            EXHW_WK2124_Write_FIFO(device, SPAGE0_FDAT(index),sendbuf,sendlen);
+        }else{
+            EXHW_WK2124_Write_FIFO(device, SPAGE0_FDAT(index),sendbuf,len);
+            ret = len;
+        }
+    }
+    return ret;
 }
 
 uint16_t Wk2124_GetBuf(struct rt_spi_device *device, uint8_t index, uint8_t *getbuf, uint16_t len)
 {
-	uint16_t ret=0, rfcnt = 0;
-	uint8_t fsr = 0;
-	
-	fsr = EXHW_WK2124_Read_Reg(device, SPAGE0_FSR(index));
-	if(fsr & 0x08 )//子串口接收FIFO未空
-	{
-		rfcnt = EXHW_WK2124_Read_Reg(device, SPAGE0_RFCNT(index));//读子串口发送fifo中数据个数
-		if(rfcnt == 0)//当RFCNT寄存器为0的时候，有两种情况，可能是256或者是0，这个时候通过FSR来判断，如果FSR显示接收FIFO不为空，就为256个字节
-		{
-			rfcnt = 256;
-		}
-		if (rfcnt < len)
-		{
-			EXHW_WK2124_Read_FIFO(device, SPAGE0_FDAT(index), getbuf, rfcnt);
-			ret = rfcnt;
-		} else {
-			EXHW_WK2124_Read_FIFO(device, SPAGE0_FDAT(index), getbuf, len);
-			ret = len;
-		}
+    uint16_t ret=0, rfcnt = 0;
+    uint8_t fsr = 0;
+    
+    fsr = EXHW_WK2124_Read_Reg(device, SPAGE0_FSR(index));
+    if(fsr & 0x08 )//子串口接收FIFO未空
+    {
+        rfcnt = EXHW_WK2124_Read_Reg(device, SPAGE0_RFCNT(index));//读子串口发送fifo中数据个数
+        if(rfcnt == 0)//当RFCNT寄存器为0的时候，有两种情况，可能是256或者是0，这个时候通过FSR来判断，如果FSR显示接收FIFO不为空，就为256个字节
+        {
+            rfcnt = 256;
+        }
+        if (rfcnt < len)
+        {
+            EXHW_WK2124_Read_FIFO(device, SPAGE0_FDAT(index), getbuf, rfcnt);
+            ret = rfcnt;
+        } else {
+            EXHW_WK2124_Read_FIFO(device, SPAGE0_FDAT(index), getbuf, len);
+            ret = len;
+        }
 
-	}
-	 return ret;	
+    }
+     return ret;    
 }
 
 void EXHW_WK2124_Init(struct rt_spi_device *device)
 {
-	/*使能子串口1,2,3,4的时钟*/
-	EXHW_WK2124_Write_Reg(device, GENA,0x0F);
-	
-	/*复位子串口1,2,3,4*/
-	EXHW_WK2124_Write_Reg(device, GRST,0x0F);
-	
-	/*使能子串口1,2,3,4的全局中断 */
-	EXHW_WK2124_Write_Reg(device, GIER,0x0F);
-	
+    /*使能子串口1,2,3,4的时钟*/
+    EXHW_WK2124_Write_Reg(device, GENA,0x0F);
+    
+    /*复位子串口1,2,3,4*/
+    EXHW_WK2124_Write_Reg(device, GRST,0x0F);
+    
+    /*使能子串口1,2,3,4的全局中断 */
+    EXHW_WK2124_Write_Reg(device, GIER,0x0F);
+    
 }
 
 void EXHW_WK2124_Disable_Tx(struct rt_spi_device *device, uint8_t index)
 {
-	uint8_t scr = 0;
+    uint8_t scr = 0;
 
-	scr = EXHW_WK2124_Read_Reg(device, SPAGE0_SCR(index)); 
-	scr &= ~(1 << 1);
-	EXHW_WK2124_Write_Reg(device, SPAGE0_SCR(index),scr);
+    scr = EXHW_WK2124_Read_Reg(device, SPAGE0_SCR(index)); 
+    scr &= ~(1 << 1);
+    EXHW_WK2124_Write_Reg(device, SPAGE0_SCR(index),scr);
 }
 
 void EXHW_WK2124_Enable_Tx(struct rt_spi_device *device, uint8_t index)
 {
-	uint8_t scr = 0;
+    uint8_t scr = 0;
 
-	scr = EXHW_WK2124_Read_Reg(device,SPAGE0_SCR(index)); 
-	scr |= (1 << 1);
-	EXHW_WK2124_Write_Reg(device,SPAGE0_SCR(index),scr);
+    scr = EXHW_WK2124_Read_Reg(device,SPAGE0_SCR(index)); 
+    scr |= (1 << 1);
+    EXHW_WK2124_Write_Reg(device,SPAGE0_SCR(index),scr);
 }
 
 void EXHW_WK2124_Disable_Rx(struct rt_spi_device *device, uint8_t index)
 {
-	uint8_t scr = 0;
-	scr = EXHW_WK2124_Read_Reg(device,SPAGE0_SCR(index)); 
-	scr &= ~(1 << 0);
-	EXHW_WK2124_Write_Reg(device,SPAGE0_SCR(index),scr);
+    uint8_t scr = 0;
+    scr = EXHW_WK2124_Read_Reg(device,SPAGE0_SCR(index)); 
+    scr &= ~(1 << 0);
+    EXHW_WK2124_Write_Reg(device,SPAGE0_SCR(index),scr);
 }
 
 void EXHW_WK2124_Enable_Rx(struct rt_spi_device *device, uint8_t index)
 {
-	uint8_t scr = 0,fcr = 0;
-	
-	//复位 n 串口的FIFO
-	fcr = EXHW_WK2124_Read_Reg(device,SPAGE0_FCR(index)); 
-	fcr |= (1 << 0);
-	EXHW_WK2124_Write_Reg(device,SPAGE0_FCR(index),fcr);
-	//使能串口 n  的接收
-	scr = EXHW_WK2124_Read_Reg(device,SPAGE0_SCR(index)); 
-	scr |= (1 << 0);
-	EXHW_WK2124_Write_Reg(device,SPAGE0_SCR(index),scr);
+    uint8_t scr = 0,fcr = 0;
+    
+    //复位 n 串口的FIFO
+    fcr = EXHW_WK2124_Read_Reg(device,SPAGE0_FCR(index)); 
+    fcr |= (1 << 0);
+    EXHW_WK2124_Write_Reg(device,SPAGE0_FCR(index),fcr);
+    //使能串口 n  的接收
+    scr = EXHW_WK2124_Read_Reg(device,SPAGE0_SCR(index)); 
+    scr |= (1 << 0);
+    EXHW_WK2124_Write_Reg(device,SPAGE0_SCR(index),scr);
 }
 
 #endif

--- a/wk2124s.h
+++ b/wk2124s.h
@@ -10,30 +10,30 @@
 #include <stdlib.h>
 
 //全局寄存器列表 共4个
-#define GENA	0x00   													/*全局控制寄存器 											R/W*/
-#define GRST  0x01   													/*全局子串口复位寄存器 								R/W*/
-#define GIER  0x10   													/*全局中断寄存器 											R/W*/
-#define GIFR  0x11   													/*全局中断标志寄存器 									R*/
+#define GENA    0x00      /* 全局控制寄存器         R/W */
+#define GRST    0x01      /* 全局子串口复位寄存器   R/W */
+#define GIER    0x10      /* 全局中断寄存器         R/W */
+#define GIFR    0x11      /*全局中断标志寄存器      R */
 
 //子串口寄存器   共18个 (x:00 --- 11)
-#define	SPAGE(x)     					((x << 4)|0x03)	/*子串口页控制寄存器 									R/W*/
+#define    SPAGE(x)             ((x << 4)|0x03) /* 子串口页控制寄存器                R/W */
 
-#define	SPAGE0_SCR(x)     		((x << 4)|0x04) /*子串口使能寄存器 										R/W*/
-#define	SPAGE0_LCR(x)     		((x << 4)|0x05) /*子串口配置寄存器 										R/W*/
-#define	SPAGE0_FCR(x)     		((x << 4)|0x06) /*子串口FIFO控制寄存器 								R/W*/
-#define	SPAGE0_SIER(x)     		((x << 4)|0x07) /*子串口中断使能寄存器 								R/W*/
-#define	SPAGE0_SIFR(x)     		((x << 4)|0x08) /*子串口中断标志寄存器 								R/W*/
-#define	SPAGE0_TFCNT(x)     	((x << 4)|0x09) /*子串口发送FIFO计数寄存器 						R*/
-#define	SPAGE0_RFCNT(x)     	((x << 4)|0x0A) /*子串口接收FIFO计数寄存器 						R*/
-#define	SPAGE0_FSR(x)     		((x << 4)|0x0B) /*子串口FIFO状态寄存器 								R*/
-#define	SPAGE0_LSR(x)     		((x << 4)|0x0C) /*子串口接收状态寄存器 								R*/
-#define	SPAGE0_FDAT(x)     		((x << 4)|0x0D) /*子串口FIFO数据寄存器 								R/W*/
+#define    SPAGE0_SCR(x)        ((x << 4)|0x04) /* 子串口使能寄存器                  R/W */
+#define    SPAGE0_LCR(x)        ((x << 4)|0x05) /* 子串口配置寄存器                  R/W */
+#define    SPAGE0_FCR(x)        ((x << 4)|0x06) /* 子串口FIFO控制寄存器              R/W */
+#define    SPAGE0_SIER(x)       ((x << 4)|0x07) /* 子串口中断使能寄存器              R/W */
+#define    SPAGE0_SIFR(x)       ((x << 4)|0x08) /* 子串口中断标志寄存器              R/W */
+#define    SPAGE0_TFCNT(x)      ((x << 4)|0x09) /* 子串口发送FIFO计数寄存器          R */
+#define    SPAGE0_RFCNT(x)      ((x << 4)|0x0A) /* 子串口接收FIFO计数寄存器          R */
+#define    SPAGE0_FSR(x)        ((x << 4)|0x0B) /* 子串口FIFO状态寄存器              R */
+#define    SPAGE0_LSR(x)        ((x << 4)|0x0C) /* 子串口接收状态寄存器              R */
+#define    SPAGE0_FDAT(x)       ((x << 4)|0x0D) /* 子串口FIFO数据寄存器              R/W */
 
-#define	SPAGE1_BAUD1(x)     	((x << 4)|0x04) /*子串口波特率配置寄存器高字节 				R/W*/
-#define	SPAGE1_BAUD0(x)     	((x << 4)|0x05) /*子穿裤波特率撇只寄存器低字节 				R/W*/
-#define	SPAGE1_PRES(x)     		((x << 4)|0x06) /*子穿裤波特率配置寄存器小数部分 			R/W*/
-#define	SPAGE1_RFTL(x)     		((x << 4)|0x07) /*子串口接收FIFO中断触发点配置寄存器 	R/W*/
-#define	SPAGE1_TFTL(x)     		((x << 4)|0x08) /*子串口发送FIFO中断触发点配置寄存器 	R/W*/
+#define    SPAGE1_BAUD1(x)      ((x << 4)|0x04) /* 子串口波特率配置寄存器高字节       R/W */
+#define    SPAGE1_BAUD0(x)      ((x << 4)|0x05) /* 子穿裤波特率撇只寄存器低字节       R/W */
+#define    SPAGE1_PRES(x)       ((x << 4)|0x06) /* 子穿裤波特率配置寄存器小数部分     R/W */
+#define    SPAGE1_RFTL(x)       ((x << 4)|0x07) /* 子串口接收FIFO中断触发点配置寄存器 R/W */
+#define    SPAGE1_TFTL(x)       ((x << 4)|0x08) /* 子串口发送FIFO中断触发点配置寄存器 R/W */
 
 
 #ifdef PKG_USING_WK2124


### PR DESCRIPTION
wk2124_usart.c
1)修改晶振参数配置方式，wk2124可以支持更多晶振
2)波特率计算方式错误修复，WK2124_Fosc/cfg->baud_rate/16 只能得到整数值
3)修复子串口没有彻底关闭，导致下次打开串口无法正常收发数据
update:
1)优化变量的内存占用

Signed-off-by: SimpleInit <63694297@qq.com>